### PR TITLE
Explicitly configure Dependabot for OGM branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency_name: "org.springframework.boot:spring-boot-starter-parent"
+        versions: [2.4.0,]


### PR DESCRIPTION
This disallows Spring Boot upgrades to 2.4.x, as these versions
do not include SDN 5 anymore.